### PR TITLE
feat: load request runtime environment from .env files

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ req
 
 # load all requests from the directory tree at the specified path
 req ./path/to/dir
+
+req --help
+Usage of req:
+  -e string
+        path to .env file (shorthand)
+  -env string
+        path to .env file
 ```
 
 ## .http File Syntax

--- a/main.go
+++ b/main.go
@@ -1,20 +1,38 @@
 package main
 
 import (
+	"bufio"
 	"context"
+	"flag"
+	"fmt"
 	"os"
+	"strings"
 
 	"github.com/go-rq/req/internal/tui"
 	"github.com/go-rq/rq"
 	"github.com/rivo/tview"
 )
 
+var envFilePath string
+
+func init() {
+	initEnvFileFlags()
+}
+
 func main() {
+	flag.Parse()
 	app := tview.NewApplication()
 	ctx := context.Background()
+	if envFilePath != "" {
+		env, err := loadEnvFile(envFilePath)
+		if err != nil {
+			panic(err)
+		}
+		ctx = rq.WithEnvironment(ctx, env)
+	}
 	path := "."
-	if len(os.Args) > 1 {
-		path = os.Args[1]
+	if flag.NArg() > 1 {
+		path = flag.Arg(0)
 	}
 	fileSelectView := tui.NewFileSelectView(path)
 	fileSelectView.SetCallback(selectFile(ctx, app, fileSelectView))
@@ -41,4 +59,31 @@ func selectRequest(ctx context.Context, app *tview.Application, prevView tui.Vie
 		rv := tui.NewRequestView(ctx, app, request, prevView)
 		rv.Mount(app)
 	}
+}
+
+func initEnvFileFlags() {
+	const usage = "path to .env file"
+	flag.StringVar(&envFilePath, "env", "", usage)
+	flag.StringVar(&envFilePath, "e", "", usage+" (shorthand)")
+}
+
+func loadEnvFile(path string) (map[string]string, error) {
+	env := map[string]string{}
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if strings.HasPrefix(strings.TrimSpace(line), "#") {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid line: %s", line)
+		}
+		env[parts[0]] = parts[1]
+	}
+	return env, nil
 }

--- a/testdata/local.env
+++ b/testdata/local.env
@@ -1,0 +1,1 @@
+host=http://localhost:8080


### PR DESCRIPTION
Allow a user to specify the environment variables to use within the runtime by passing in a .env file to the CLI using the `-e` or `--env` flags.

ex.,
```shell
req -e testdata/local.env testdata
```
would load the environment data contained within `testdata/local.env` and then open the request select menu within the `testdata` directory.