### PR TITLE
fix: Reload files on view change

### DIFF
--- a/internal/tui/file_select.go
+++ b/internal/tui/file_select.go
@@ -106,6 +106,7 @@ func (f *FileSelect) renderList(values []string) {
 }
 
 func (f *FileSelect) Mount(app *tview.Application) {
+	f.listFiles(httpFileFilter)
 	app.SetRoot(f.layout, true)
 }
 

--- a/main.go
+++ b/main.go
@@ -44,11 +44,7 @@ func main() {
 
 func selectFile(ctx context.Context, app *tview.Application, prevView tui.View) func(string) {
 	return func(path string) {
-		reqs, err := rq.ParseFromFile(path)
-		if err != nil {
-			panic(err)
-		}
-		rv := tui.NewRequestSelectView(app, reqs, prevView)
+		rv := tui.NewRequestSelectView(app, path, prevView)
 		rv.SetCallback(selectRequest(ctx, app, rv))
 		rv.Mount(app)
 	}


### PR DESCRIPTION
Fix an issue where the filesystem can easily fall out of sync with the file list or request list stored in memory. The long-term solution should be to add in file watchers and watch for changes to the file tree where the process is operating and reload files at that point, this change is smaller to implement. The current implementation is:

* Each time the `FileSelect` view is mounted, it will re-walk the file tree and load matched files.
* Each time the `RequestSelect` view is mounted, the file is reloaded again to pick up any changes to the request script.